### PR TITLE
Add processors for SPM and connectors support

### DIFF
--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Get changed files
         id: changes
         run: |
-          echo "md=$(git diff --name-only --diff-filter=ACMRTUXB $(git merge-base origin/main $PR_HEAD) $PR_HEAD | grep .md$ | xargs)" >> $GITHUB_OUTPUT
+          echo "md=$(git diff --name-only --diff-filter=ACMRTUXB $(git merge-base origin/main $PR_HEAD) $PR_HEAD | grep .md$ | grep -v README.md | xargs)" >> $GITHUB_OUTPUT
 
   check-links:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -129,3 +129,116 @@ Here is a list of community roles with current and previous members:
   - [Anthony Mirabella](https://github.com/Aneurysm9)
 
 Learn more about roles in the [community repository](https://github.com/open-telemetry/community/blob/main/community-membership.md).
+
+# Configuration Example
+
+Replace `<<LOGZIO_TRACING_SHIPPING_TOKEN>>`, `<<LOGZIO_SPM_SHIPPING_TOKEN>>`, `<<LOGZIO_ACCOUNT_REGION_CODE>>`, and `<<LOGZIO_LISTENER_HOST>>` with your Logz.io account's information.
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: "0.0.0.0:4317"
+      http:
+        endpoint: "0.0.0.0:4318"
+
+connectors:
+  spanmetrics:
+    aggregation_temporality: AGGREGATION_TEMPORALITY_CUMULATIVE
+    dimensions:
+      - name: rpc.grpc.status_code
+      - name: http.method
+      - name: http.status_code
+      - name: cloud.provider
+      - name: cloud.region
+      - name: db.system
+      - name: messaging.system
+      - default: DEV
+        name: env_id
+    dimensions_cache_size: 100000
+    histogram:
+      explicit:
+        buckets:
+          - 2ms
+          - 8ms
+          - 50ms
+          - 100ms
+          - 200ms
+          - 500ms
+          - 1s
+          - 5s
+          - 10s
+    metrics_expiration: 5m
+    resource_metrics_key_attributes:
+      - service.name
+      - telemetry.sdk.language
+      - telemetry.sdk.name
+
+exporters:
+  logzio/traces:
+    account_token: <<LOGZIO_TRACING_SHIPPING_TOKEN>>
+    region: <<LOGZIO_ACCOUNT_REGION_CODE>>
+  prometheusremotewrite/spm:
+    endpoint: https://<<LOGZIO_LISTENER_HOST>>:8053
+    add_metric_suffixes: false
+    headers:
+      Authorization: Bearer <<LOGZIO_SPM_SHIPPING_TOKEN>>
+
+processors:
+  batch:
+  tail_sampling:
+    policies:
+      - name: policy-errors
+        type: status_code
+        status_code: {status_codes: [ERROR]}
+      - name: policy-slow
+        type: latency
+        latency: {threshold_ms: 1000}
+      - name: policy-random-ok
+        type: probabilistic
+        probabilistic: {sampling_percentage: 10}
+  metricstransform/metrics-rename:
+    transforms:
+    - include: ^duration(.*)$$
+      action: update
+      match_type: regexp
+      new_name: latency.$${1} 
+    - action: update
+      include: calls
+      new_name: calls_total
+  metricstransform/labels-rename:
+    transforms:
+    - action: update
+      include: ^latency
+      match_type: regexp
+      operations:
+      - action: update_label
+        label: span.name
+        new_label: operation
+    - action: update
+      include: ^calls
+      match_type: regexp
+      operations:
+      - action: update_label
+        label: span.name
+        new_label: operation  
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [tail_sampling, batch]
+      exporters: [logzio/traces]
+    traces/spm:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [spanmetrics]
+    metrics/spanmetrics:
+      receivers: [spanmetrics]
+      processors: [metricstransform/metrics-rename, metricstransform/labels-rename, batch]
+      exporters: [prometheusremotewrite/spm]
+  telemetry: 
+    logs:
+      level: "info"
+```

--- a/collector/go.mod
+++ b/collector/go.mod
@@ -126,9 +126,11 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheusremotewrite v0.113.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.113.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.113.0 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.113.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor v0.113.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.113.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor v0.113.0 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.113.0 // indirect
 	github.com/open-telemetry/opentelemetry-lambda/collector/processor/coldstartprocessor v0.98.0 // indirect
 	github.com/open-telemetry/opentelemetry-lambda/collector/processor/decoupleprocessor v0.0.0-00010101000000-000000000000 // indirect
 	github.com/open-telemetry/opentelemetry-lambda/collector/receiver/telemetryapireceiver v0.98.0 // indirect

--- a/collector/go.sum
+++ b/collector/go.sum
@@ -196,6 +196,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter v0.113
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter v0.113.0/go.mod h1:sYIh0S63ztcL2q9gEKhvviDQ5caH1sFE1oeFRDQOQ6A=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/pdatautil v0.113.0 h1:V9CRl77lPG2xFPpnRf1QLiePo7FZngt+vw6M2KLdRMU=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/pdatautil v0.113.0/go.mod h1:zL+Msnlb1TEObHQ2RNnPKbVr3GhSdyI2ZqGtiSxg2/E=
+github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.113.0 h1:5YU2trp7n56EyDS9dEyY1UxyaW6wxB4KiyKoyjDYooo=
+github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.113.0/go.mod h1:EBtBK1lE/HMUz51cafBLlJAXZ/2ZDRCV4C+rT04fMYM=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.113.0 h1:e2WOkaj5AWPaKTU4l+GEXGrEUbrAhQPQ7zLUdnXLGX8=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.113.0/go.mod h1:x+DR/o7xddbdhpQP2QKBJkPUdrj2tl/uR1OJ/sqlrWc=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.113.0 h1:GERkhEtH3Uk8CMBzFoBmMD7fBfcrtIM9hopbQqzdvNs=
@@ -216,12 +218,16 @@ github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributespr
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.113.0/go.mod h1:U0wBuG6Jz+DBzcPNCmRVZaZTXqaKC+RYo4eJiSKJwwk=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.113.0 h1:+eYxV9vp6u8fKM+9acEJYGUa3SD1vJF776c/haougNQ=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.113.0/go.mod h1:xSVeb2A5wmIuJ9Vak9UwPCP/yN1SDd+pBKfYHROW6YE=
+github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.113.0 h1:MN9P2YH7SUTLxQqGEmLsTKJ77qCSXBxHFE3seJxjH14=
+github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.113.0/go.mod h1:2WUdA+8uuoNLofhsNDHLyejeVpVzAvyHMVw3jWpvOGE=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor v0.113.0 h1:zDScLkNf/llyiH1cjpVv5PhJAT5AcHIXCB35zW5jsbM=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor v0.113.0/go.mod h1:S+GR7FZJYtFBnbjgD737QImuvm8d4+PBccpI0Xrda4E=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.113.0 h1:Syf4U5GrSl2fOGXBAChHrdSvMRBhi7BFiDwKbFkNo/8=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.113.0/go.mod h1:Q9shex5tQOoK4FeVx0NvYkwu18hCPFlRnwqqQzLfbpo=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor v0.113.0 h1:fvasZ3NNW+O5pVnDTF4+WuscMLQQRbUROhK7McVjRD8=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor v0.113.0/go.mod h1:AESjWVG6+DrQKX1xFnChVKlNiSHi8gwX4k7kAQJfnSo=
+github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.113.0 h1:vgYhhliqQ6WUy5b1BE0ILJQKTweaLDPI5l/bUIunqLo=
+github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.113.0/go.mod h1:UG/8zqyqbdN0HHkiWC7GZW4wFL4GIyRtsshc1RY8bGo=
 github.com/pierrec/lz4/v4 v4.1.21 h1:yOVMLb6qSIDP67pl/5F7RepeKYu/VmTyEXvuMI5d9mQ=
 github.com/pierrec/lz4/v4 v4.1.21/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/collector/lambdacomponents/default.go
+++ b/collector/lambdacomponents/default.go
@@ -36,6 +36,7 @@ import (
 	"go.opentelemetry.io/collector/exporter/otlpexporter"
 	"go.opentelemetry.io/collector/exporter/otlphttpexporter"
 	"go.opentelemetry.io/collector/extension"
+	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/otelcol"
 	"go.opentelemetry.io/collector/processor"
 	"go.opentelemetry.io/collector/processor/batchprocessor"
@@ -98,6 +99,14 @@ func Components(extensionID string) (otelcol.Factories, error) {
 	connectors, err := connector.MakeFactoryMap(
 		spanmetricsconnector.NewFactory(),
 	)
+	if err != nil {
+		errs = append(errs, err)
+	}
+
+	err = featuregate.GlobalRegistry().Set("connector.spanmetrics.legacyMetricNames", true)
+	if err != nil {
+		errs = append(errs, err)
+	}
 
 	factories := otelcol.Factories{
 		Receivers:  receivers,

--- a/collector/lambdacomponents/default.go
+++ b/collector/lambdacomponents/default.go
@@ -17,16 +17,20 @@
 package lambdacomponents
 
 import (
+	"github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/logzioexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/sigv4authextension"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor"
 	"github.com/open-telemetry/opentelemetry-lambda/collector/processor/decoupleprocessor"
+	"go.opentelemetry.io/collector/connector"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/debugexporter"
 	"go.opentelemetry.io/collector/exporter/otlpexporter"
@@ -76,6 +80,8 @@ func Components(extensionID string) (otelcol.Factories, error) {
 		coldstartprocessor.NewFactory(),
 		decoupleprocessor.NewFactory(),
 		batchprocessor.NewFactory(),
+		tailsamplingprocessor.NewFactory(),
+		metricstransformprocessor.NewFactory(),
 	)
 	if err != nil {
 		errs = append(errs, err)
@@ -89,11 +95,16 @@ func Components(extensionID string) (otelcol.Factories, error) {
 		errs = append(errs, err)
 	}
 
+	connectors, err := connector.MakeFactoryMap(
+		spanmetricsconnector.NewFactory(),
+	)
+
 	factories := otelcol.Factories{
 		Receivers:  receivers,
 		Exporters:  exporters,
 		Processors: processors,
 		Extensions: extensions,
+		Connectors: connectors,
 	}
 
 	return factories, multierr.Combine(errs...)

--- a/collector/lambdacomponents/go.mod
+++ b/collector/lambdacomponents/go.mod
@@ -10,9 +10,11 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/sigv4authextension v0.113.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.113.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.113.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.113.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor v0.113.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.113.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor v0.113.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.113.0
 	github.com/open-telemetry/opentelemetry-lambda/collector/processor/coldstartprocessor v0.98.0
 	github.com/open-telemetry/opentelemetry-lambda/collector/processor/decoupleprocessor v0.0.0-00010101000000-000000000000
 	github.com/open-telemetry/opentelemetry-lambda/collector/receiver/telemetryapireceiver v0.98.0

--- a/collector/lambdacomponents/go.sum
+++ b/collector/lambdacomponents/go.sum
@@ -180,6 +180,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter v0.113
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter v0.113.0/go.mod h1:sYIh0S63ztcL2q9gEKhvviDQ5caH1sFE1oeFRDQOQ6A=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/pdatautil v0.113.0 h1:V9CRl77lPG2xFPpnRf1QLiePo7FZngt+vw6M2KLdRMU=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/pdatautil v0.113.0/go.mod h1:zL+Msnlb1TEObHQ2RNnPKbVr3GhSdyI2ZqGtiSxg2/E=
+github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.113.0 h1:5YU2trp7n56EyDS9dEyY1UxyaW6wxB4KiyKoyjDYooo=
+github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.113.0/go.mod h1:EBtBK1lE/HMUz51cafBLlJAXZ/2ZDRCV4C+rT04fMYM=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.113.0 h1:e2WOkaj5AWPaKTU4l+GEXGrEUbrAhQPQ7zLUdnXLGX8=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.113.0/go.mod h1:x+DR/o7xddbdhpQP2QKBJkPUdrj2tl/uR1OJ/sqlrWc=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.113.0 h1:GERkhEtH3Uk8CMBzFoBmMD7fBfcrtIM9hopbQqzdvNs=
@@ -200,12 +202,16 @@ github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributespr
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.113.0/go.mod h1:U0wBuG6Jz+DBzcPNCmRVZaZTXqaKC+RYo4eJiSKJwwk=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.113.0 h1:+eYxV9vp6u8fKM+9acEJYGUa3SD1vJF776c/haougNQ=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.113.0/go.mod h1:xSVeb2A5wmIuJ9Vak9UwPCP/yN1SDd+pBKfYHROW6YE=
+github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.113.0 h1:MN9P2YH7SUTLxQqGEmLsTKJ77qCSXBxHFE3seJxjH14=
+github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.113.0/go.mod h1:2WUdA+8uuoNLofhsNDHLyejeVpVzAvyHMVw3jWpvOGE=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor v0.113.0 h1:zDScLkNf/llyiH1cjpVv5PhJAT5AcHIXCB35zW5jsbM=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor v0.113.0/go.mod h1:S+GR7FZJYtFBnbjgD737QImuvm8d4+PBccpI0Xrda4E=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.113.0 h1:Syf4U5GrSl2fOGXBAChHrdSvMRBhi7BFiDwKbFkNo/8=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.113.0/go.mod h1:Q9shex5tQOoK4FeVx0NvYkwu18hCPFlRnwqqQzLfbpo=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor v0.113.0 h1:fvasZ3NNW+O5pVnDTF4+WuscMLQQRbUROhK7McVjRD8=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor v0.113.0/go.mod h1:AESjWVG6+DrQKX1xFnChVKlNiSHi8gwX4k7kAQJfnSo=
+github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.113.0 h1:vgYhhliqQ6WUy5b1BE0ILJQKTweaLDPI5l/bUIunqLo=
+github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.113.0/go.mod h1:UG/8zqyqbdN0HHkiWC7GZW4wFL4GIyRtsshc1RY8bGo=
 github.com/pierrec/lz4/v4 v4.1.21 h1:yOVMLb6qSIDP67pl/5F7RepeKYu/VmTyEXvuMI5d9mQ=
 github.com/pierrec/lz4/v4 v4.1.21/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=


### PR DESCRIPTION
- Add `tail_sampling` and `metricstransformprocessor` processors
- Add support for connectors 
  - To allow using the `spanmetrics`