### PR TITLE
[DEV] update release workflow layer name

### DIFF
--- a/.github/workflows/layer-publish.yml
+++ b/.github/workflows/layer-publish.yml
@@ -110,3 +110,11 @@ jobs:
             --principal "*" \
             --statement-id publish \
             --action lambda:GetLayerVersion
+          echo "${LAYER_VERSION}" > layer-version.txt
+
+      - name: Upload Layer Version artifact
+        uses: actions/upload-artifact@v4
+        if: ${{ inputs.architecture == 'amd64' && inputs.aws_region == 'us-east-1' }}
+        with:
+          name: layer-version
+          path: layer-version.txt

--- a/.github/workflows/release-layer-collector.yml
+++ b/.github/workflows/release-layer-collector.yml
@@ -81,7 +81,7 @@ jobs:
           - us-west-2
     with:
       artifact-name: opentelemetry-collector-layer-${{ matrix.architecture }}.zip
-      layer-name: opentelemetry-collector
+      layer-name: logzio-opentelemetry-collector
       component-version: ${{needs.build-layer.outputs.COLLECTOR_VERSION}}
       architecture: ${{ matrix.architecture }}
       release-group: prod

--- a/.github/workflows/release-layer-collector.yml
+++ b/.github/workflows/release-layer-collector.yml
@@ -96,19 +96,29 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Download Layer version
+        uses: actions/download-artifact@v4
+        with:
+          name: layer-version
+
+      - name: Read Layer version
+        id: layer-version
+        run: echo "::set-output name=version::$(cat layer-version.txt)"
+
       - name: Append Layer ARNs to Release Body
         run: |
           COLLECTOR_VERSION=${{ needs.build-layer.outputs.COLLECTOR_VERSION }}
+          LAYER_VERSION=${{ steps.layer-version.outputs.version }}
 
           MESSAGE="### Lambda Layers for OpenTelemetry Collector (${COLLECTOR_VERSION})\n\n"
           MESSAGE+="The following Lambda layers are available for this release. Use the appropriate ARN for your Lambda architecture:\n\n"
           MESSAGE+="#### 🖥️ **amd64 (x86_64)**\n"
           MESSAGE+="\`\`\`\n"
-          MESSAGE+="arn:aws:lambda:<region>:486140753397:layer:logzio-opentelemetry-collector-amd64-${COLLECTOR_VERSION//./_}:1\n"
+          MESSAGE+="arn:aws:lambda:<region>:486140753397:layer:logzio-opentelemetry-collector-amd64-${COLLECTOR_VERSION//./_}:$LAYER_VERSION\n"
           MESSAGE+="\`\`\`\n\n"
           MESSAGE+="#### 📱 **arm64**\n"
           MESSAGE+="\`\`\`\n"
-          MESSAGE+="arn:aws:lambda:<region>:486140753397:layer:logzio-opentelemetry-collector-arm64-${COLLECTOR_VERSION//./_}:1\n"
+          MESSAGE+="arn:aws:lambda:<region>:486140753397:layer:logzio-opentelemetry-collector-arm64-${COLLECTOR_VERSION//./_}:$LAYER_VERSION\n"
           MESSAGE+="\`\`\`\n\n"
 
           # Append the message to the release notes


### PR DESCRIPTION
- Align the release layer name to match the layer name we provide in the release description
- Ensure the layer version is updated consistently
  - This change assumes that all layers versions in all regions are the same.
  - The reason for this, is that the current setup uses a general `layer-publish.yaml` workflow for all layers. This workflow is where we get the new layer version. However, the text in the release notes is only updated for the collector layer.
  - So in order to pass the layer version from `layer-publish.yaml` workflow >> `release-layer-collector.yaml` workflow, we generate a single artifact with one of the versions, this is the version we update at the release description.

**Future considerations:**
In the future, if additional regions are added, we should change this workaround to a more stable solution.
Perhaps generating a text that works for any layer and potentially include a table with the relevant ARN per region, similar to other solutions we have.