### PR TITLE
Use config.combined.yaml as the default collector config for combined layers

### DIFF
--- a/collector/config.combined.yaml
+++ b/collector/config.combined.yaml
@@ -1,0 +1,68 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: "localhost:4317"
+      http:
+        endpoint: "localhost:4318"
+  telemetryapireceiver:
+    types: ["platform", "function", "extension"]
+
+processors:
+  batch:
+  # Jaeger (classic) rejects non-scalar tags (arrays/maps). Drop array attributes
+  # (process.command_args, aws.log.group.names, process.tags) to prevent "invalid tag type" 500s.
+  # If you need these values, stringify arrays with a transform processor instead of dropping.
+  attributes/drop_array_tags:
+    actions:
+      - key: process.command_args
+        action: delete
+      - key: aws.log.group.names
+        action: delete
+      - key: process.tags
+        action: delete
+  resource/drop_array_tags:
+    attributes:
+      - key: process.command_args
+        action: delete
+      - key: aws.log.group.names
+        action: delete
+      - key: process.tags
+        action: delete
+  
+exporters:
+  logzio/logs:
+    account_token: "${env:LOGZIO_LOGS_TOKEN}"
+    region: "${env:LOGZIO_REGION}"
+    headers:
+      user-agent: logzio-opentelemetry-layer-logs
+  logzio/traces:
+    account_token: "${env:LOGZIO_TRACES_TOKEN}"
+    region: "${env:LOGZIO_REGION}"
+    headers:
+      user-agent: logzio-opentelemetry-layer-traces
+  prometheusremotewrite:
+    endpoint: "https://listener.logz.io:8053"
+    headers:
+      Authorization: "Bearer ${env:LOGZIO_METRICS_TOKEN}"
+      user-agent: logzio-opentelemetry-layer-metrics
+    target_info:
+      enabled: false
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp, telemetryapireceiver]
+      processors: [resource/drop_array_tags, attributes/drop_array_tags, batch]
+      exporters: [logzio/traces]
+    metrics:
+      receivers: [otlp, telemetryapireceiver]
+      processors: [batch]
+      exporters: [prometheusremotewrite]
+    logs:
+      receivers: [telemetryapireceiver]
+      processors: [batch]
+      exporters: [logzio/logs]
+  telemetry:
+    logs:
+      level: "info"

--- a/go/build-combined.sh
+++ b/go/build-combined.sh
@@ -34,6 +34,10 @@ mkdir -p "$BUILD_DIR/combined-layer/extensions"
 mkdir -p "$BUILD_DIR/combined-layer/collector-config"
 cp "$COLLECTOR_DIR/build/extensions"/* "$BUILD_DIR/combined-layer/extensions/"
 cp "$COLLECTOR_DIR/config"* "$BUILD_DIR/combined-layer/collector-config/"
+# Prefer the combined production config as the default if present
+if [ -f "$COLLECTOR_DIR/config.combined.yaml" ]; then
+  cp "$COLLECTOR_DIR/config.combined.yaml" "$BUILD_DIR/combined-layer/collector-config/config.yaml"
+fi
 
 
 echo "Step 2: Creating combined layer package..."

--- a/java/build-combined.sh
+++ b/java/build-combined.sh
@@ -77,6 +77,11 @@ mkdir -p "$WORKSPACE_DIR/collector-config"
 cp "$COLLECTOR_DIR/build/extensions"/* "$WORKSPACE_DIR/extensions/"
 cp "$COLLECTOR_DIR/config.yaml" "$WORKSPACE_DIR/collector-config/"
 
+# Prefer the combined production config as the default if present
+if [[ -f "$COLLECTOR_DIR/config.combined.yaml" ]]; then
+  cp "$COLLECTOR_DIR/config.combined.yaml" "$WORKSPACE_DIR/collector-config/config.yaml"
+fi
+
 # Include E2E-specific collector config for testing workflows
 if [[ -f "$COLLECTOR_DIR/config.e2e.yaml" ]]; then
   cp "$COLLECTOR_DIR/config.e2e.yaml" "$WORKSPACE_DIR/collector-config/"

--- a/nodejs/packages/layer/build-combined.sh
+++ b/nodejs/packages/layer/build-combined.sh
@@ -57,6 +57,11 @@ mkdir -p "$WORKSPACE_DIR/collector-config"
 cp "$COLLECTOR_DIR/build/extensions"/* "$WORKSPACE_DIR/extensions/"
 cp "$COLLECTOR_DIR/config.yaml" "$WORKSPACE_DIR/collector-config/"
 
+# Prefer the combined production config as the default if present
+if [ -f "$COLLECTOR_DIR/config.combined.yaml" ]; then
+	cp "$COLLECTOR_DIR/config.combined.yaml" "$WORKSPACE_DIR/collector-config/config.yaml"
+fi
+
 # Include E2E-specific collector config for testing workflows
 if [ -f "$COLLECTOR_DIR/config.e2e.yaml" ]; then
 	cp "$COLLECTOR_DIR/config.e2e.yaml" "$WORKSPACE_DIR/collector-config/"

--- a/python/src/build-combined.sh
+++ b/python/src/build-combined.sh
@@ -55,6 +55,10 @@ mkdir -p "$WORKSPACE_DIR/extensions"
 mkdir -p "$WORKSPACE_DIR/collector-config"
 cp "$COLLECTOR_DIR/build/extensions"/* "$WORKSPACE_DIR/extensions/"
 cp "$COLLECTOR_DIR/config.yaml" "$WORKSPACE_DIR/collector-config/"
+# Prefer the combined production config as the default if present
+if [ -f "$COLLECTOR_DIR/config.combined.yaml" ]; then
+    cp "$COLLECTOR_DIR/config.combined.yaml" "$WORKSPACE_DIR/collector-config/config.yaml"
+fi
 # Include E2E-specific collector config for testing workflows
 if [ -f "$COLLECTOR_DIR/config.e2e.yaml" ]; then
     cp "$COLLECTOR_DIR/config.e2e.yaml" "$WORKSPACE_DIR/collector-config/"

--- a/ruby/build-combined.sh
+++ b/ruby/build-combined.sh
@@ -55,6 +55,9 @@ mkdir -p "$BUILD_DIR/combined-layer/extensions"
 mkdir -p "$BUILD_DIR/combined-layer/collector-config"
 cp "$COLLECTOR_DIR/build/extensions"/* "$BUILD_DIR/combined-layer/extensions/"
 cp "$COLLECTOR_DIR/config.yaml" "$BUILD_DIR/combined-layer/collector-config/"
+if [ -f "$COLLECTOR_DIR/config.combined.yaml" ]; then
+  cp "$COLLECTOR_DIR/config.combined.yaml" "$BUILD_DIR/combined-layer/collector-config/config.yaml"
+fi
 if [ -f "$COLLECTOR_DIR/config.e2e.yaml" ]; then
   cp "$COLLECTOR_DIR/config.e2e.yaml" "$BUILD_DIR/combined-layer/collector-config/"
 fi


### PR DESCRIPTION
This PR adds a new production-ready configuration, `collector/config.combined.yaml`, and updates all combined layer build scripts to install it as the default `/opt/collector-config/config.yaml`.

This change avoids the build failure caused by the deprecated `service.telemetry.metrics.address` key in the old default config. It ensures that the combined layers work out-of-the-box without requiring users to set the `OPENTELEMETRY_COLLECTOR_CONFIG_URI` environment variable.

### Changes
- Added `collector/config.combined.yaml`.
- Updated the following build scripts to prefer the new config as the default:
  - `java/build-combined.sh`
  - `python/src/build-combined.sh`
  - `nodejs/packages/layer/build-combined.sh`
  - `ruby/build-combined.sh`
  - `go/build-combined.sh`

### Behavior
If `collector/config.combined.yaml` exists, it is copied to `collector-config/config.yaml` within the layer. Otherwise, the existing `collector/config.yaml` is used as a fallback.

### Notes
- The default config path used by the collector remains `/opt/collector-config/config.yaml`.
- Users can still override this default by setting `OPENTELEMETRY_COLLECTOR_CONFIG_URI` if needed.